### PR TITLE
fix: ユーザー名に英数字とアンダースコアのみを許可するバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :name, presence: true, uniqueness: true, length: { maximum: 20 }
+  validates :name,
+            presence: true,
+            uniqueness: true,
+            length: { maximum: 20 },
+            format: { with: /\A[a-zA-Z0-9_]+\z/, message: 'only allows letters, digits, and underscores' }
   has_many :likes, dependent: :destroy
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  content    :string(100)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  post_id    :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_post_id  (post_id)
+#  index_comments_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class CommentSerializer < ActiveModel::Serializer
   attributes :content, :user_name, :user_avatar
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  name                   :string           not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_name                  (name) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class UserSerializer < ActiveModel::Serializer
   attributes :name, :avatar_url
 end

--- a/db/migrate/20251122112059_add_name_format_constraint_to_users.rb
+++ b/db/migrate/20251122112059_add_name_format_constraint_to_users.rb
@@ -1,0 +1,11 @@
+class AddNameFormatConstraintToUsers < ActiveRecord::Migration[7.2]
+  def up
+    add_check_constraint :users,
+                         "name ~ '^[a-zA-Z0-9_]+$'",
+                         name: 'users_name_format'
+  end
+
+  def down
+    remove_check_constraint :users, name: 'users_name_format'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_19_145226) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_22_112059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_19_145226) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.check_constraint "name::text ~ '^[a-zA-Z0-9_]+$'::text", name: "users_name_format"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,8 +20,8 @@
 #
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.unique.email }
-    password { Faker::Internet.unique.password }
-    name { Faker::Name.unique.name[0...20] }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    sequence(:name) { |n| "user_#{n}" }
+    password { 'password123' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe User, type: :model do
     end
   end
 
+  context 'name に無効な文字が含まれる場合' do
+    ['john-doe', 'john.doe', 'john@doe', 'john doe', 'user!', '田中太郎'].each do |invalid_name|
+      it "#{invalid_name.inspect} は無効" do
+        user = build(:user, name: invalid_name)
+
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to be_present
+      end
+    end
+  end
+
   context 'email が空の場合' do
     let(:user) { build(:user, email: nil) }
 


### PR DESCRIPTION


## 概要

ユーザー名に英数字とアンダースコアのみを許可するバリデーションを追加
