### PR TITLE
refactor: APIエンドポイントを整理（auth/users分離）

### DIFF
--- a/app/controllers/api/auth/login_controller.rb
+++ b/app/controllers/api/auth/login_controller.rb
@@ -1,4 +1,4 @@
-class Api::Users::AuthController < ApplicationController
+class Api::Auth::LoginController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index

--- a/app/controllers/api/auth/logout_controller.rb
+++ b/app/controllers/api/auth/logout_controller.rb
@@ -1,4 +1,4 @@
-class Api::Users::LogoutController < ApplicationController
+class Api::Auth::LogoutController < ApplicationController
   def destroy
     sign_out(:user)
     head :no_content

--- a/app/controllers/api/auth/token_controller.rb
+++ b/app/controllers/api/auth/token_controller.rb
@@ -1,4 +1,4 @@
-class Api::Users::TokenExchangesController < ApplicationController
+class Api::Auth::TokenController < ApplicationController
   skip_before_action :authenticate_user!
 
   def show

--- a/app/controllers/api/relationships_controller.rb
+++ b/app/controllers/api/relationships_controller.rb
@@ -1,12 +1,12 @@
 class Api::RelationshipsController < ApplicationController
   def create
-    user = User.find(params[:account_id])
+    user = User.find(params[:user_id])
     current_user.follow!(user)
     head :created
   end
 
   def destroy
-    user = User.find(params[:account_id])
+    user = User.find(params[:user_id])
     current_user.unfollow!(user)
     head :no_content
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,4 @@
-class Api::AccountsController < ApplicationController
+class Api::UsersController < ApplicationController
   def index
     searchable_users = User.select(:id, :name).with_attached_avatar.limit(100)
     render json: searchable_users, each_serializer: UserSerializer

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -317,7 +317,7 @@ Devise.setup do |config|
     jwt.expiration_time = 1.month.to_i
     jwt.dispatch_requests = []
     jwt.revocation_requests = [
-      ['DELETE', %r{\A/api/users/logout\z}]
+      ['DELETE', %r{\A/api/auth/logout\z}]
     ]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,13 @@ Rails.application.routes.draw do
   end
 
   namespace :api, defaults: { format: 'json' } do
-    namespace :users do
-      get '/auth', to: 'auth#index'
-      get 'token_exchange', to: 'token_exchanges#show'
+    namespace :auth do
+      get 'login', to: 'login#index'
+      get 'token', to: 'token#show'
       delete 'logout', to: 'logout#destroy'
     end
-    resources :accounts, only: %i[index] do
-      resource  :relationship, only: %i[create destroy]
+    resources :users, only: %i[index] do
+      resource :relationship, only: %i[create destroy]
     end
     resource :me, only: %i[show update], controller: :me
     resources :posts, only: %i[index show create update destroy] do

--- a/spec/requests/api/logout_spec.rb
+++ b/spec/requests/api/logout_spec.rb
@@ -4,9 +4,9 @@ require 'swagger_helper'
 RSpec.describe 'User Logout API', type: :request do
   let(:user) { create(:user) }
 
-  path '/api/users/logout' do
+  path '/api/auth/logout' do
     delete 'ログアウトする' do
-      tags 'User'
+      tags 'Auth'
       produces 'application/json'
       parameter name: 'Authorization',
                 in: :header,

--- a/spec/requests/api/relationships_spec.rb
+++ b/spec/requests/api/relationships_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 require 'swagger_helper'
 
 RSpec.describe 'Api::Relationships', type: :request do
-  path '/api/accounts/{account_id}/relationship' do
-    parameter name: :account_id, in: :path, required: true, schema: { type: :integer }
+  path '/api/users/{user_id}/relationship' do
+    parameter name: :user_id, in: :path, required: true, schema: { type: :integer }
 
     post 'フォロー関係を作成する' do
       tags 'Relationship'
       consumes 'application/json'
       produces 'application/json'
 
-      let(:account) { create(:user) }
-      let(:account_id) { account.id }
+      let(:target_user) { create(:user) }
+      let(:user_id) { target_user.id }
 
       response '201', 'フォロー成功' do
         let(:current_user) { create(:user) }
         before { sign_in current_user }
         run_test! do
           expect(response).to have_http_status(:created)
-          expect(current_user.followings).to include(account)
+          expect(current_user.followings).to include(target_user)
         end
       end
 
@@ -32,7 +32,7 @@ RSpec.describe 'Api::Relationships', type: :request do
         let(:current_user) { create(:user) }
         before do
           sign_in current_user
-          create(:relationship, follower: current_user, following: account)
+          create(:relationship, follower: current_user, following: target_user)
         end
         run_test! do
           expect(response).to have_http_status(:unprocessable_content)
@@ -44,14 +44,14 @@ RSpec.describe 'Api::Relationships', type: :request do
       tags 'Relationship'
       produces 'application/json'
 
-      let(:account) { create(:user) }
-      let(:account_id) { account.id }
+      let(:target_user) { create(:user) }
+      let(:user_id) { target_user.id }
 
       response '204', 'フォロー削除成功' do
         let(:current_user) { create(:user) }
         before do
           sign_in current_user
-          create(:relationship, follower: current_user, following: account)
+          create(:relationship, follower: current_user, following: target_user)
         end
         run_test! do
           expect(response).to have_http_status(:no_content)

--- a/spec/requests/api/token_exchange_spec.rb
+++ b/spec/requests/api/token_exchange_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'User Token Exchange API', type: :request do
     allow(Rails.application.config.x).to receive(:redis).and_return(redis)
   end
 
-  path '/api/users/token_exchange' do
+  path '/api/auth/token' do
     get '認可コードからJWTを取得する' do
-      tags 'User'
+      tags 'Auth'
       produces 'application/json'
       parameter name: :auth_code, in: :query, required: true, schema: { type: :string }
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 require 'swagger_helper'
 
-RSpec.describe 'Api::Accounts', type: :request do
-  path '/api/accounts' do
-    get 'アカウント一覧を取得する' do
-      tags 'Account'
+RSpec.describe 'Api::Users', type: :request do
+  path '/api/users' do
+    get 'ユーザー一覧を取得する' do
+      tags 'User'
       produces 'application/json'
 
       let!(:users) { create_list(:user, 3) }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -4,29 +4,6 @@ info:
   title: API Documentation
   version: '1.0'
 paths:
-  "/api/accounts":
-    get:
-      summary: アカウント一覧を取得する
-      tags:
-      - Account
-      responses:
-        '200':
-          description: アカウント一覧取得成功
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    avatarUrl:
-                      type: string
-                      nullable: true
-                  required:
-                  - name
-                  - avatarUrl
   "/api/posts/{post_id}/comments":
     parameters:
     - name: post_id
@@ -149,11 +126,11 @@ paths:
                     type: string
                 required:
                 - error
-  "/api/users/logout":
+  "/api/auth/logout":
     delete:
       summary: ログアウトする
       tags:
-      - User
+      - Auth
       parameters:
       - name: Authorization
         in: header
@@ -622,9 +599,9 @@ paths:
                     type: string
                 required:
                 - error
-  "/api/accounts/{account_id}/relationship":
+  "/api/users/{user_id}/relationship":
     parameters:
-    - name: account_id
+    - name: user_id
       in: path
       required: true
       schema:
@@ -651,11 +628,11 @@ paths:
           description: 未ログイン
         '404':
           description: フォローしていない相手を削除しようとした場合
-  "/api/users/token_exchange":
+  "/api/auth/token":
     get:
       summary: 認可コードからJWTを取得する
       tags:
-      - User
+      - Auth
       parameters:
       - name: auth_code
         in: query
@@ -690,6 +667,29 @@ paths:
                       type: string
                 required:
                 - errors
+  "/api/users":
+    get:
+      summary: ユーザー一覧を取得する
+      tags:
+      - User
+      responses:
+        '200':
+          description: アカウント一覧取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    avatarUrl:
+                      type: string
+                      nullable: true
+                  required:
+                  - name
+                  - avatarUrl
 servers:
 - url: https://{defaultHost}
   variables:


### PR DESCRIPTION
## 概要

同じ `User` モデルに対して `users/`（認証）、`accounts`（一覧）、`me`（自分）と3つの異なるパスが存在し、FE開発者にとって分かりにくい構造だったため、認証系を `auth/` に、ユーザーデータ系を `users/` に整理した。

## 変更内容

### エンドポイントの移動

| Before | After | Method |
|--------|-------|--------|
| `/api/users/auth` | `/api/auth/login` | GET |
| `/api/users/token_exchange` | `/api/auth/token` | GET |
| `/api/users/logout` | `/api/auth/logout` | DELETE |
| `/api/accounts` | `/api/users` | GET |
| `/api/accounts/:account_id/relationship` | `/api/users/:user_id/relationship` | POST/DELETE |

### ファイル変更

- **コントローラー**: `api/users/` 配下の認証系3ファイルを `api/auth/` に移動、`accounts_controller` を `users_controller` にリネーム
- **ルーティング**: `namespace :users` → `namespace :auth`、`resources :accounts` → `resources :users`
- **Devise JWT設定**: `revocation_requests` のパスを `/api/auth/logout` に更新
- **テスト**: 全specファイルのパス・タグ・変数名を更新、`accounts_spec.rb` → `users_spec.rb` にリネーム
- **Swagger**: `rswag:specs:swaggerize` で再生成済み

### 変更なし

- `/api/me`、`/api/posts/*` — 変更なし
- `devise_for :users` と `omniauth_callbacks_controller` — 一切変更なし



## テスト方法

- `bundle exec rspec` で全テストが通ること（※既存の blocked host 403 / model test の失敗は本PR以前から存在）
- `bundle exec rails routes | grep api` で新しいルーティングが正しいことを確認
- `bundle exec rails rswag:specs:swaggerize` でSwaggerが正しく生成されることを確認