### PR TITLE
feat: フォロワー/フォロー中一覧エンドポイントを追加

### DIFF
--- a/app/controllers/api/users/followers_controller.rb
+++ b/app/controllers/api/users/followers_controller.rb
@@ -1,0 +1,14 @@
+class Api::Users::FollowersController < ApplicationController
+  PER_PAGE = 20
+
+  def index
+    user = User.find(params[:user_id])
+    page = [params.fetch(:page, 1).to_i, 1].max
+    followers = user.followers
+                    .with_attached_avatar
+                    .order(created_at: :desc)
+                    .offset((page - 1) * PER_PAGE)
+                    .limit(PER_PAGE)
+    render json: followers, each_serializer: UserSerializer, following_user_ids: current_user.following_ids.to_set
+  end
+end

--- a/app/controllers/api/users/followings_controller.rb
+++ b/app/controllers/api/users/followings_controller.rb
@@ -1,0 +1,14 @@
+class Api::Users::FollowingsController < ApplicationController
+  PER_PAGE = 20
+
+  def index
+    user = User.find(params[:user_id])
+    page = [params.fetch(:page, 1).to_i, 1].max
+    followings = user.followings
+                     .with_attached_avatar
+                     .order(created_at: :desc)
+                     .offset((page - 1) * PER_PAGE)
+                     .limit(PER_PAGE)
+    render json: followings, each_serializer: UserSerializer, following_user_ids: current_user.following_ids.to_set
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     resources :users, only: %i[index show] do
       resource :relationship, only: %i[create destroy]
       resources :posts, only: %i[index], controller: 'users/posts'
+      resources :followers, only: %i[index], controller: 'users/followers'
+      resources :followings, only: %i[index], controller: 'users/followings'
     end
     resource :me, only: %i[show update], controller: :me
     resources :notifications, only: %i[index] do

--- a/spec/requests/api/users/followers_spec.rb
+++ b/spec/requests/api/users/followers_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'Api::Users::Followers', type: :request do
+  path '/api/users/{user_id}/followers' do
+    parameter name: :user_id, in: :path, required: true, schema: { type: :integer }
+
+    get '特定ユーザーのフォロワー一覧を取得する' do
+      tags 'User Follower'
+      produces 'application/json'
+      parameter name: :page, in: :query, required: false, schema: { type: :integer }
+
+      let(:user) { create(:user) }
+      let(:target_user) { create(:user) }
+      let(:user_id) { target_user.id }
+
+      response '200', 'フォロワー一覧取得成功' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   name: { type: :string },
+                   avatarUrl: { type: :string, nullable: true },
+                   isFollowing: { type: :boolean }
+                 },
+                 required: %w[id name avatarUrl isFollowing]
+               }
+
+        let!(:followers) do
+          create_list(:user, 3).each { |f| f.follow!(target_user) }
+        end
+
+        before { sign_in user }
+
+        run_test! do
+          expect(json_response.size).to eq(3)
+          returned_ids = json_response.map { |u| u['id'] }
+          expect(returned_ids).to match_array(followers.map(&:id))
+        end
+      end
+
+      response '401', '未ログイン' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string }
+               },
+               required: %w[error]
+
+        run_test!
+      end
+
+      response '404', '存在しないユーザー' do
+        let(:user_id) { 999_999 }
+
+        before { sign_in user }
+
+        run_test!
+      end
+    end
+  end
+
+  describe 'isFollowing判定' do
+    let(:user) { create(:user) }
+    let(:target_user) { create(:user) }
+    let!(:follower_a) { create(:user) }
+    let!(:follower_b) { create(:user) }
+
+    before do
+      follower_a.follow!(target_user)
+      follower_b.follow!(target_user)
+      user.follow!(follower_a)
+      sign_in user
+    end
+
+    it 'ログインユーザーがフォロー済みのユーザーはisFollowing=trueになる' do
+      get "/api/users/#{target_user.id}/followers"
+      followed = json_response.find { |u| u['id'] == follower_a.id }
+      not_followed = json_response.find { |u| u['id'] == follower_b.id }
+      expect(followed['isFollowing']).to be true
+      expect(not_followed['isFollowing']).to be false
+    end
+  end
+
+  describe 'ページネーション' do
+    let(:user) { create(:user) }
+    let(:target_user) { create(:user) }
+
+    before { sign_in user }
+
+    context '25人のフォロワーがいる場合' do
+      let!(:followers) do
+        create_list(:user, 25).each { |f| f.follow!(target_user) }
+      end
+
+      it '1ページ目は20件を返す' do
+        get "/api/users/#{target_user.id}/followers", params: { page: 1 }
+        expect(json_response.size).to eq(20)
+      end
+
+      it '2ページ目は残り5件を返す' do
+        get "/api/users/#{target_user.id}/followers", params: { page: 2 }
+        expect(json_response.size).to eq(5)
+      end
+
+      it '3ページ目は空配列を返す' do
+        get "/api/users/#{target_user.id}/followers", params: { page: 3 }
+        expect(json_response.size).to eq(0)
+      end
+    end
+
+    context '不正なpageパラメータ' do
+      let!(:follower) { create(:user).tap { |f| f.follow!(target_user) } }
+
+      it 'page=0 は1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followers", params: { page: 0 }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+
+      it 'page=-1 は1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followers", params: { page: -1 }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+
+      it '非数値のpageは1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followers", params: { page: 'abc' }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/api/users/followers_spec.rb
+++ b/spec/requests/api/users/followers_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe 'Api::Users::Followers', type: :request do
       end
     end
 
+    context '並び順' do
+      let!(:old_follower) { create(:user, created_at: 2.days.ago) }
+      let!(:new_follower) { create(:user, created_at: 1.hour.ago) }
+
+      before do
+        old_follower.follow!(target_user)
+        new_follower.follow!(target_user)
+      end
+
+      it '新しいフォロワーが先に返る' do
+        get "/api/users/#{target_user.id}/followers"
+        expect(json_response.first['id']).to eq(new_follower.id)
+        expect(json_response.last['id']).to eq(old_follower.id)
+      end
+    end
+
     context '不正なpageパラメータ' do
       let!(:follower) { create(:user).tap { |f| f.follow!(target_user) } }
 

--- a/spec/requests/api/users/followings_spec.rb
+++ b/spec/requests/api/users/followings_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'Api::Users::Followings', type: :request do
+  path '/api/users/{user_id}/followings' do
+    parameter name: :user_id, in: :path, required: true, schema: { type: :integer }
+
+    get '特定ユーザーのフォロー中一覧を取得する' do
+      tags 'User Following'
+      produces 'application/json'
+      parameter name: :page, in: :query, required: false, schema: { type: :integer }
+
+      let(:user) { create(:user) }
+      let(:target_user) { create(:user) }
+      let(:user_id) { target_user.id }
+
+      response '200', 'フォロー中一覧取得成功' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   name: { type: :string },
+                   avatarUrl: { type: :string, nullable: true },
+                   isFollowing: { type: :boolean }
+                 },
+                 required: %w[id name avatarUrl isFollowing]
+               }
+
+        let!(:followings) do
+          create_list(:user, 3).each { |f| target_user.follow!(f) }
+        end
+
+        before { sign_in user }
+
+        run_test! do
+          expect(json_response.size).to eq(3)
+          returned_ids = json_response.map { |u| u['id'] }
+          expect(returned_ids).to match_array(followings.map(&:id))
+        end
+      end
+
+      response '401', '未ログイン' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string }
+               },
+               required: %w[error]
+
+        run_test!
+      end
+
+      response '404', '存在しないユーザー' do
+        let(:user_id) { 999_999 }
+
+        before { sign_in user }
+
+        run_test!
+      end
+    end
+  end
+
+  describe 'isFollowing判定' do
+    let(:user) { create(:user) }
+    let(:target_user) { create(:user) }
+    let!(:following_a) { create(:user) }
+    let!(:following_b) { create(:user) }
+
+    before do
+      target_user.follow!(following_a)
+      target_user.follow!(following_b)
+      user.follow!(following_a)
+      sign_in user
+    end
+
+    it 'ログインユーザーがフォロー済みのユーザーはisFollowing=trueになる' do
+      get "/api/users/#{target_user.id}/followings"
+      followed = json_response.find { |u| u['id'] == following_a.id }
+      not_followed = json_response.find { |u| u['id'] == following_b.id }
+      expect(followed['isFollowing']).to be true
+      expect(not_followed['isFollowing']).to be false
+    end
+  end
+
+  describe 'ページネーション' do
+    let(:user) { create(:user) }
+    let(:target_user) { create(:user) }
+
+    before { sign_in user }
+
+    context '25人をフォローしている場合' do
+      let!(:followings) do
+        create_list(:user, 25).each { |f| target_user.follow!(f) }
+      end
+
+      it '1ページ目は20件を返す' do
+        get "/api/users/#{target_user.id}/followings", params: { page: 1 }
+        expect(json_response.size).to eq(20)
+      end
+
+      it '2ページ目は残り5件を返す' do
+        get "/api/users/#{target_user.id}/followings", params: { page: 2 }
+        expect(json_response.size).to eq(5)
+      end
+
+      it '3ページ目は空配列を返す' do
+        get "/api/users/#{target_user.id}/followings", params: { page: 3 }
+        expect(json_response.size).to eq(0)
+      end
+    end
+
+    context '不正なpageパラメータ' do
+      let!(:following) { create(:user).tap { |f| target_user.follow!(f) } }
+
+      it 'page=0 は1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followings", params: { page: 0 }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+
+      it 'page=-1 は1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followings", params: { page: -1 }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+
+      it '非数値のpageは1ページ目として扱う' do
+        get "/api/users/#{target_user.id}/followings", params: { page: 'abc' }
+        expect(response).to have_http_status(:ok)
+        expect(json_response.size).to eq(1)
+      end
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/api/users/followings_spec.rb
+++ b/spec/requests/api/users/followings_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe 'Api::Users::Followings', type: :request do
       end
     end
 
+    context '並び順' do
+      let!(:old_following) { create(:user, created_at: 2.days.ago) }
+      let!(:new_following) { create(:user, created_at: 1.hour.ago) }
+
+      before do
+        target_user.follow!(old_following)
+        target_user.follow!(new_following)
+      end
+
+      it '新しいフォロー中ユーザーが先に返る' do
+        get "/api/users/#{target_user.id}/followings"
+        expect(json_response.first['id']).to eq(new_following.id)
+        expect(json_response.last['id']).to eq(old_following.id)
+      end
+    end
+
     context '不正なpageパラメータ' do
       let!(:following) { create(:user).tap { |f| target_user.follow!(f) } }
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -861,6 +861,114 @@ paths:
                       type: string
                 required:
                 - errors
+  "/api/users/{user_id}/followers":
+    parameters:
+    - name: user_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: 特定ユーザーのフォロワー一覧を取得する
+      tags:
+      - User Follower
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: フォロワー一覧取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    avatarUrl:
+                      type: string
+                      nullable: true
+                    isFollowing:
+                      type: boolean
+                  required:
+                  - id
+                  - name
+                  - avatarUrl
+                  - isFollowing
+        '401':
+          description: 未ログイン
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
+        '404':
+          description: 存在しないユーザー
+  "/api/users/{user_id}/followings":
+    parameters:
+    - name: user_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: 特定ユーザーのフォロー中一覧を取得する
+      tags:
+      - User Following
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: フォロー中一覧取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    avatarUrl:
+                      type: string
+                      nullable: true
+                    isFollowing:
+                      type: boolean
+                  required:
+                  - id
+                  - name
+                  - avatarUrl
+                  - isFollowing
+        '401':
+          description: 未ログイン
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
+        '404':
+          description: 存在しないユーザー
   "/api/users/{user_id}/posts":
     parameters:
     - name: user_id


### PR DESCRIPTION
## 概要

各ユーザーのフォロワー・フォロー中一覧を取得するAPIエンドポイントを追加。既存の `UserSerializer` を再利用し、ページネーション（20件/ページ）に対応。

## 変更内容

- `GET /api/users/:user_id/followers` — フォロワー一覧エンドポイントを追加
- `GET /api/users/:user_id/followings` — フォロー中一覧エンドポイントを追加
- 両エンドポイントとも `page` パラメータによるページネーション対応
- `UserSerializer` を再利用し、`isFollowing` でログインユーザーのフォロー状態を返却

### ファイル構成

| ファイル | 操作 |
|---------|------|
| `config/routes.rb` | ルート2行追加 |
| `app/controllers/api/users/followers_controller.rb` | 新規（`PostsController`パターン踏襲） |
| `app/controllers/api/users/followings_controller.rb` | 新規（同上） |
| `spec/requests/api/users/followers_spec.rb` | 新規（rswag + ページネーション + isFollowing検証） |
| `spec/requests/api/users/followings_spec.rb` | 新規（同上） |
| `swagger/swagger.yaml` | 自動再生成 |

## レビューポイント

- コントローラは `users/posts_controller.rb` と同じパターン。N+1防止に `with_attached_avatar` を使用
- シリアライザ・モデルの変更なし

## テスト方法

```bash
RAILS_ENV=test bundle exec rspec spec/requests/api/users/followers_spec.rb spec/requests/api/users/followings_spec.rb
# 20 examples, 0 failures
```

テストカバレッジ: 200（正常）、401（未認証）、404（存在しないユーザー）、isFollowing判定、ページネーション（20件区切り・不正page値）