### PR TITLE
fix: #81 APIコントローラーのエラーハンドリング改善

### DIFF
--- a/app/controllers/api/me_controller.rb
+++ b/app/controllers/api/me_controller.rb
@@ -9,8 +9,6 @@ class Api::MeController < ApplicationController
       current_user.avatar.purge if remove_avatar?
     end
     render json: current_user, serializer: UserDetailSerializer, following_user_ids: Set.new
-  rescue ActiveRecord::RecordInvalid
-    render json: { errors: current_user.errors.full_messages }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/api/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,8 @@ class Api::Users::OmniauthCallbacksController < Devise::OmniauthCallbacksControl
     auth_code = SecureRandom.hex(16)
     Rails.application.config.x.redis.setex("auth_code:#{auth_code}", 60, user.id)
     redirect_to "#{ENV.fetch('FRONTEND_URL')}/auth-callback?auth_code=#{auth_code}", allow_other_host: true
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error("OmniAuth google_oauth2 failed: #{e.class} - #{e.message}")
       redirect_to "#{ENV.fetch('FRONTEND_URL')}/?auth_error=google", allow_other_host: true
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,14 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_active_storage_url_options
 
+  rescue_from ActiveRecord::RecordNotFound do
+    render json: { errors: ['Not found'] }, status: :not_found
+  end
+
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
   private
 
   def set_active_storage_url_options

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe 'Api::Posts', type: :request do
         run_test!
       end
 
+      response '404', '投稿が存在しない' do
+        schema type: :object,
+               properties: {
+                 errors: { type: :array, items: { type: :string } }
+               },
+               required: %w[errors]
+
+        let(:id) { 999_999 }
+
+        before { sign_in user }
+
+        run_test!
+      end
+
       response '401', '未ログイン' do
         schema type: :object,
                properties: {
@@ -248,6 +262,15 @@ RSpec.describe 'Api::Posts', type: :request do
 
       it '404を返す' do
         patch '/api/posts/999999', params: { post: { caption: 'test' } }, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'GET /api/posts/:id 存在しないIDを指定した場合' do
+      before { sign_in owner }
+
+      it '404を返す' do
+        get '/api/posts/999999'
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -697,6 +697,19 @@ paths:
                 - isOwn
                 - mostRecentLikerName
                 - comments
+        '404':
+          description: 投稿が存在しない
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - errors
         '401':
           description: 未ログイン
           content:


### PR DESCRIPTION
## 関連Issue

Close #81

## 概要

本番環境で `.find()` が `RecordNotFound` を raise した際、JSON ではなく HTML の 404 ページが返る問題を修正。また OAuth コントローラーがエラーをログなしで握り潰していた問題にログ出力を追加。

## 変更内容

- **`ApplicationController` に `rescue_from` を集約** — `RecordNotFound` → 404 JSON、`RecordInvalid` → 422 JSON を一括ハンドリング
- **`Api::MeController` のインライン rescue を削除** — 集約ハンドラで同じ挙動になるため不要
- **OAuth コントローラーにエラーログ出力を追加** — `StandardError` を握り潰していた箇所に `Rails.logger.error` を追加
- **`GET /api/posts/:id` の 404 テストを追加** — request spec + rswag response 定義を追加し swagger.yaml に反映

## レビューポイント

- `ApplicationController` への集約で既存の挙動が変わらないか（`MeController` の `RecordInvalid` ハンドリングが同等であること）
- 汎用 `StandardError` catch-all は意図的に追加していない（開発時のデバッグを妨げるため）

## テスト方法

```bash
# コンテナ内で実行
RAILS_ENV=test bundle exec rspec spec/requests/  # 162 examples, 0 failures
bundle exec rubocop --auto-correct               # no offenses
RAILS_ENV=test bundle exec rake rswag:specs:swaggerize  # swagger.yaml 再生成
```