### PR TITLE
feat: タイムラインエンドポイントを追加

### DIFF
--- a/app/controllers/api/timelines_controller.rb
+++ b/app/controllers/api/timelines_controller.rb
@@ -1,10 +1,29 @@
 class Api::TimelinesController < ApplicationController
+  PER_PAGE = 20
+
   def index
     posts = Post
               .timeline_for(current_user)
               .with_list
-              .limit(20)
-              .order(created_at: :desc)
-    render json: posts, each_serializer: PostSerializer, scope: current_user
+              .then { |rel| cursor ? rel.where('posts.id < ?', cursor) : rel }
+              .order(id: :desc)
+              .limit(PER_PAGE + 1)
+
+    has_more = posts.size > PER_PAGE
+    posts = posts.first(PER_PAGE)
+
+    render json: {
+      posts: ActiveModelSerializers::SerializableResource.new(
+        posts, each_serializer: PostSerializer, scope: current_user
+      ),
+      nextCursor: has_more ? posts.last&.id&.to_s : nil,
+      hasMore: has_more
+    }
+  end
+
+  private
+
+  def cursor
+    params[:cursor]&.to_i
   end
 end

--- a/app/controllers/api/timelines_controller.rb
+++ b/app/controllers/api/timelines_controller.rb
@@ -1,17 +1,10 @@
 class Api::TimelinesController < ApplicationController
   def index
     posts = Post
-              .where(user_id: timeline_user_ids)
-              .or(Post.where(user_id: current_user.id))
+              .timeline_for(current_user)
               .with_list
               .limit(20)
               .order(created_at: :desc)
     render json: posts, each_serializer: PostSerializer, scope: current_user
-  end
-
-  private
-
-  def timeline_user_ids
-    Relationship.where(follower_id: current_user.id).select(:following_id)
   end
 end

--- a/app/controllers/api/timelines_controller.rb
+++ b/app/controllers/api/timelines_controller.rb
@@ -1,0 +1,17 @@
+class Api::TimelinesController < ApplicationController
+  def index
+    posts = Post
+              .where(user_id: timeline_user_ids)
+              .or(Post.where(user_id: current_user.id))
+              .with_list
+              .limit(20)
+              .order(created_at: :desc)
+    render json: posts, each_serializer: PostSerializer, scope: current_user
+  end
+
+  private
+
+  def timeline_user_ids
+    Relationship.where(follower_id: current_user.id).select(:following_id)
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -37,6 +37,11 @@ class Post < ApplicationRecord
       .with_attached_images
   }
 
+  scope :timeline_for, ->(user) {
+    following_ids = Relationship.where(follower_id: user.id).select(:following_id)
+    where(user_id: following_ids).or(where(user_id: user.id))
+  }
+
   def owned_by?(user)
     return false unless user
     user_id == user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         post :read_all, to: 'notifications/read_all#create'
       end
     end
+    resources :timeline, only: %i[index], controller: :timelines
     resources :posts, only: %i[index show create update destroy] do
       resource :like, only: %i[create destroy], module: :posts
       resources :comments, only: %i[create destroy], module: :posts

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -87,6 +87,42 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  describe '.timeline_for' do
+    let(:followed_user) { create(:user) }
+    let(:unfollowed_user) { create(:user) }
+
+    before { create(:relationship, follower: owner, following: followed_user) }
+
+    it 'フォロー中ユーザーの投稿を含む' do
+      post = create(:post, user: followed_user)
+      expect(Post.timeline_for(owner)).to include(post)
+    end
+
+    it '自分の投稿を含む' do
+      post = create(:post, user: owner)
+      expect(Post.timeline_for(owner)).to include(post)
+    end
+
+    it '未フォローユーザーの投稿を含まない' do
+      post = create(:post, user: unfollowed_user)
+      expect(Post.timeline_for(owner)).not_to include(post)
+    end
+
+    it '複数フォローユーザーの投稿を全て含む' do
+      second_followed = create(:user)
+      create(:relationship, follower: owner, following: second_followed)
+      post1 = create(:post, user: followed_user)
+      post2 = create(:post, user: second_followed)
+      expect(Post.timeline_for(owner)).to include(post1, post2)
+    end
+
+    it 'フォローも投稿もないユーザーは空を返す' do
+      loner = create(:user)
+      create(:post, user: unfollowed_user)
+      expect(Post.timeline_for(loner)).to be_empty
+    end
+  end
+
   describe '#owned_by?' do
     let(:post) { create(:post, user: owner) }
     let(:other_user) { create(:user) }

--- a/spec/requests/api/timelines_spec.rb
+++ b/spec/requests/api/timelines_spec.rb
@@ -7,43 +7,177 @@ RSpec.describe 'Api::Timelines', type: :request do
     get 'タイムラインを取得する' do
       tags 'Timeline'
       produces 'application/json'
+      parameter name: :cursor, in: :query, type: :string, required: false,
+                description: '前回取得した最後の投稿のID'
 
       let(:user) { create(:user) }
 
-      response '200', '取得成功' do
-        schema type: :array,
-               items: {
-                 type: :object,
-                 properties: POST_LIST_PROPERTIES,
-                 required: POST_LIST_REQUIRED
-               }
+      response '200', 'フォロー中ユーザーと自分の投稿が返る' do
+        let(:followed_user) { create(:user) }
+        let!(:followed_post) { create(:post, user: followed_user) }
+        let!(:own_post) { create(:post, user: user) }
+        let!(:unfollowed_post) { create(:post) }
 
-        context 'フォロー中ユーザーと自分の投稿が返る' do
-          let(:followed_user) { create(:user) }
-          let!(:followed_post) { create(:post, user: followed_user) }
-          let!(:own_post) { create(:post, user: user) }
-          let!(:unfollowed_post) { create(:post) }
-
-          before do
-            create(:relationship, follower: user, following: followed_user)
-            sign_in user
-          end
-
-          run_test! do
-            ids = json_response.map { |p| p['id'] }
-            expect(ids).to include(followed_post.id, own_post.id)
-            expect(ids).not_to include(unfollowed_post.id)
-          end
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
         end
 
-        context 'フォローなし・自分の投稿もない場合は空配列' do
-          let!(:other_post) { create(:post) }
+        run_test! do
+          posts = json_response['posts']
+          ids = posts.map { |p| p['id'] }
+          expect(ids).to include(followed_post.id, own_post.id)
+          expect(ids).not_to include(unfollowed_post.id)
+        end
+      end
 
-          before { sign_in user }
+      response '200', 'フォローなし・自分の投稿もない場合は空配列' do
+        let!(:other_post) { create(:post) }
 
-          run_test! do
-            expect(json_response).to eq([])
-          end
+        before { sign_in user }
+
+        run_test! do
+          expect(json_response['posts']).to eq([])
+          expect(json_response['hasMore']).to be false
+          expect(json_response['nextCursor']).to be_nil
+        end
+      end
+
+      response '200', '新しい投稿が先に並ぶ' do
+        let(:followed_user) { create(:user) }
+        let!(:old_post) { create(:post, user: followed_user) }
+        let!(:new_post) { create(:post, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          ids = json_response['posts'].map { |p| p['id'] }
+          expect(ids).to eq([new_post.id, old_post.id])
+        end
+      end
+
+      response '200', 'cursorより前の投稿のみ返る' do
+        let(:followed_user) { create(:user) }
+        let!(:older_post) { create(:post, user: followed_user) }
+        let!(:newer_post) { create(:post, user: followed_user) }
+        let(:cursor) { newer_post.id.to_s }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          ids = json_response['posts'].map { |p| p['id'] }
+          expect(ids).to include(older_post.id)
+          expect(ids).not_to include(newer_post.id)
+        end
+      end
+
+      response '200', 'nextCursorが最後の投稿のIDを返す' do
+        let(:followed_user) { create(:user) }
+        let!(:posts) { create_list(:post, 21, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          returned_posts = json_response['posts']
+          expect(json_response['nextCursor']).to eq(returned_posts.last['id'].to_s)
+        end
+      end
+
+      response '200', 'nextCursorで2ページ目を取得すると重複・欠落がない' do
+        let(:followed_user) { create(:user) }
+        let!(:posts) { create_list(:post, 25, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          page1_ids = json_response['posts'].map { |p| p['id'] }
+          next_cursor = json_response['nextCursor']
+
+          get '/api/timeline', params: { cursor: next_cursor }
+          page2_ids = json_response['posts'].map { |p| p['id'] }
+
+          expect(page1_ids.size).to eq(20)
+          expect(page2_ids.size).to eq(5)
+          expect(page1_ids & page2_ids).to be_empty
+          all_ids = followed_user.posts.pluck(:id).sort.reverse
+          expect(page1_ids + page2_ids).to eq(all_ids)
+        end
+      end
+
+      response '200', 'ちょうど20件の場合はhasMoreがfalseになる' do
+        let(:followed_user) { create(:user) }
+        let!(:posts) { create_list(:post, 20, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          expect(json_response['posts'].size).to eq(20)
+          expect(json_response['hasMore']).to be false
+          expect(json_response['nextCursor']).to be_nil
+        end
+      end
+
+      response '200', '21件の場合はhasMoreがtrueで20件返る' do
+        let(:followed_user) { create(:user) }
+        let!(:posts) { create_list(:post, 21, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          expect(json_response['posts'].size).to eq(20)
+          expect(json_response['hasMore']).to be true
+          expect(json_response['nextCursor']).to be_present
+        end
+      end
+
+      response '200', 'タイムライン取得成功' do
+        schema type: :object,
+               properties: {
+                 posts: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: POST_LIST_PROPERTIES,
+                     required: POST_LIST_REQUIRED
+                   }
+                 },
+                 nextCursor: { type: :string, nullable: true },
+                 hasMore: { type: :boolean }
+               },
+               required: %w[posts hasMore]
+
+        let(:followed_user) { create(:user) }
+        let!(:post_item) { create(:post, user: followed_user) }
+
+        before do
+          create(:relationship, follower: user, following: followed_user)
+          sign_in user
+        end
+
+        run_test! do
+          expect(response).to have_http_status(:ok)
+          expect(json_response).to have_key('posts')
+          expect(json_response).to have_key('hasMore')
+          expect(json_response).to have_key('nextCursor')
+          expect(json_response['posts']).to be_an(Array)
         end
       end
 

--- a/spec/requests/api/timelines_spec.rb
+++ b/spec/requests/api/timelines_spec.rb
@@ -11,142 +11,7 @@ RSpec.describe 'Api::Timelines', type: :request do
                 description: '前回取得した最後の投稿のID'
 
       let(:user) { create(:user) }
-
-      response '200', 'フォロー中ユーザーと自分の投稿が返る' do
-        let(:followed_user) { create(:user) }
-        let!(:followed_post) { create(:post, user: followed_user) }
-        let!(:own_post) { create(:post, user: user) }
-        let!(:unfollowed_post) { create(:post) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          posts = json_response['posts']
-          ids = posts.map { |p| p['id'] }
-          expect(ids).to include(followed_post.id, own_post.id)
-          expect(ids).not_to include(unfollowed_post.id)
-        end
-      end
-
-      response '200', 'フォローなし・自分の投稿もない場合は空配列' do
-        let!(:other_post) { create(:post) }
-
-        before { sign_in user }
-
-        run_test! do
-          expect(json_response['posts']).to eq([])
-          expect(json_response['hasMore']).to be false
-          expect(json_response['nextCursor']).to be_nil
-        end
-      end
-
-      response '200', '新しい投稿が先に並ぶ' do
-        let(:followed_user) { create(:user) }
-        let!(:old_post) { create(:post, user: followed_user) }
-        let!(:new_post) { create(:post, user: followed_user) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          ids = json_response['posts'].map { |p| p['id'] }
-          expect(ids).to eq([new_post.id, old_post.id])
-        end
-      end
-
-      response '200', 'cursorより前の投稿のみ返る' do
-        let(:followed_user) { create(:user) }
-        let!(:older_post) { create(:post, user: followed_user) }
-        let!(:newer_post) { create(:post, user: followed_user) }
-        let(:cursor) { newer_post.id.to_s }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          ids = json_response['posts'].map { |p| p['id'] }
-          expect(ids).to include(older_post.id)
-          expect(ids).not_to include(newer_post.id)
-        end
-      end
-
-      response '200', 'nextCursorが最後の投稿のIDを返す' do
-        let(:followed_user) { create(:user) }
-        let!(:posts) { create_list(:post, 21, user: followed_user) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          returned_posts = json_response['posts']
-          expect(json_response['nextCursor']).to eq(returned_posts.last['id'].to_s)
-        end
-      end
-
-      response '200', 'nextCursorで2ページ目を取得すると重複・欠落がない' do
-        let(:followed_user) { create(:user) }
-        let!(:posts) { create_list(:post, 25, user: followed_user) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          page1_ids = json_response['posts'].map { |p| p['id'] }
-          next_cursor = json_response['nextCursor']
-
-          get '/api/timeline', params: { cursor: next_cursor }
-          page2_ids = json_response['posts'].map { |p| p['id'] }
-
-          expect(page1_ids.size).to eq(20)
-          expect(page2_ids.size).to eq(5)
-          expect(page1_ids & page2_ids).to be_empty
-          all_ids = followed_user.posts.pluck(:id).sort.reverse
-          expect(page1_ids + page2_ids).to eq(all_ids)
-        end
-      end
-
-      response '200', 'ちょうど20件の場合はhasMoreがfalseになる' do
-        let(:followed_user) { create(:user) }
-        let!(:posts) { create_list(:post, 20, user: followed_user) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          expect(json_response['posts'].size).to eq(20)
-          expect(json_response['hasMore']).to be false
-          expect(json_response['nextCursor']).to be_nil
-        end
-      end
-
-      response '200', '21件の場合はhasMoreがtrueで20件返る' do
-        let(:followed_user) { create(:user) }
-        let!(:posts) { create_list(:post, 21, user: followed_user) }
-
-        before do
-          create(:relationship, follower: user, following: followed_user)
-          sign_in user
-        end
-
-        run_test! do
-          expect(json_response['posts'].size).to eq(20)
-          expect(json_response['hasMore']).to be true
-          expect(json_response['nextCursor']).to be_present
-        end
-      end
+      let(:followed_user) { create(:user) }
 
       response '200', 'タイムライン取得成功' do
         schema type: :object,
@@ -162,9 +27,8 @@ RSpec.describe 'Api::Timelines', type: :request do
                  nextCursor: { type: :string, nullable: true },
                  hasMore: { type: :boolean }
                },
-               required: %w[posts hasMore]
+               required: %w[posts nextCursor hasMore]
 
-        let(:followed_user) { create(:user) }
         let!(:post_item) { create(:post, user: followed_user) }
 
         before do
@@ -172,13 +36,21 @@ RSpec.describe 'Api::Timelines', type: :request do
           sign_in user
         end
 
-        run_test! do
-          expect(response).to have_http_status(:ok)
-          expect(json_response).to have_key('posts')
-          expect(json_response).to have_key('hasMore')
-          expect(json_response).to have_key('nextCursor')
-          expect(json_response['posts']).to be_an(Array)
-        end
+        run_test!
+      end
+
+      response '400', 'cursorが不正' do
+        schema type: :object,
+               properties: {
+                 errors: { type: :array, items: { type: :string } }
+               },
+               required: %w[errors]
+
+        let(:cursor) { 'invalid' }
+
+        before { sign_in user }
+
+        run_test!
       end
 
       response '401', '未ログイン' do
@@ -189,6 +61,151 @@ RSpec.describe 'Api::Timelines', type: :request do
                required: %w[error]
 
         run_test!
+      end
+    end
+  end
+
+  describe 'タイムライン取得' do
+    let(:user) { create(:user) }
+    let(:followed_user) { create(:user) }
+
+    before do
+      create(:relationship, follower: user, following: followed_user)
+      sign_in user
+    end
+
+    context 'フォロー中ユーザーと自分の投稿' do
+      let!(:followed_post) { create(:post, user: followed_user) }
+      let!(:own_post) { create(:post, user: user) }
+      let!(:unfollowed_post) { create(:post) }
+
+      it 'フォロー中と自分の投稿のみ含まれる' do
+        get '/api/timeline'
+        ids = json_response['posts'].map { |p| p['id'] }
+        expect(ids).to include(followed_post.id, own_post.id)
+        expect(ids).not_to include(unfollowed_post.id)
+      end
+    end
+
+    context 'フォローなし・自分の投稿もない場合' do
+      let(:no_follow_user) { create(:user) }
+      let!(:other_post) { create(:post) }
+
+      before { sign_in no_follow_user }
+
+      it '空配列を返す' do
+        get '/api/timeline'
+        expect(json_response['posts']).to eq([])
+        expect(json_response['hasMore']).to be false
+        expect(json_response['nextCursor']).to be_nil
+      end
+    end
+
+    context '投稿の順序' do
+      let!(:old_post) { create(:post, user: followed_user) }
+      let!(:new_post) { create(:post, user: followed_user) }
+
+      it '新しい投稿が先に並ぶ' do
+        get '/api/timeline'
+        ids = json_response['posts'].map { |p| p['id'] }
+        expect(ids).to eq([new_post.id, old_post.id])
+      end
+    end
+
+    context '複数ユーザーをフォローしている場合' do
+      let(:another_user) { create(:user) }
+      let!(:post_a) { create(:post, user: followed_user) }
+      let!(:post_b) { create(:post, user: another_user) }
+      let!(:post_c) { create(:post, user: followed_user) }
+
+      before { create(:relationship, follower: user, following: another_user) }
+
+      it '全フォローユーザーの投稿がID降順で返る' do
+        get '/api/timeline'
+        ids = json_response['posts'].map { |p| p['id'] }
+        expect(ids).to eq([post_c.id, post_b.id, post_a.id])
+      end
+    end
+  end
+
+  describe 'カーソルベースページネーション' do
+    let(:user) { create(:user) }
+    let(:followed_user) { create(:user) }
+
+    before do
+      create(:relationship, follower: user, following: followed_user)
+      sign_in user
+    end
+
+    context 'cursorが指定された場合' do
+      let!(:older_post) { create(:post, user: followed_user) }
+      let!(:newer_post) { create(:post, user: followed_user) }
+
+      it 'cursorより前の投稿のみ返る' do
+        get '/api/timeline', params: { cursor: newer_post.id.to_s }
+        ids = json_response['posts'].map { |p| p['id'] }
+        expect(ids).to include(older_post.id)
+        expect(ids).not_to include(newer_post.id)
+      end
+    end
+
+    context '21件の場合' do
+      let!(:posts) { create_list(:post, 21, user: followed_user) }
+
+      it 'hasMoreがtrueで20件返り、nextCursorが最後の投稿IDになる' do
+        get '/api/timeline'
+        returned_posts = json_response['posts']
+        expect(returned_posts.size).to eq(20)
+        expect(json_response['hasMore']).to be true
+        expect(json_response['nextCursor']).to eq(returned_posts.last['id'].to_s)
+      end
+    end
+
+    context 'ちょうど20件の場合' do
+      let!(:posts) { create_list(:post, 20, user: followed_user) }
+
+      it 'hasMoreがfalseでnextCursorがnilになる' do
+        get '/api/timeline'
+        expect(json_response['posts'].size).to eq(20)
+        expect(json_response['hasMore']).to be false
+        expect(json_response['nextCursor']).to be_nil
+      end
+    end
+
+    context 'nextCursorで2ページ目を取得した場合' do
+      let!(:posts) { create_list(:post, 25, user: followed_user) }
+
+      it '重複・欠落がない' do
+        get '/api/timeline'
+        page1_ids = json_response['posts'].map { |p| p['id'] }
+        next_cursor = json_response['nextCursor']
+
+        get '/api/timeline', params: { cursor: next_cursor }
+        page2_ids = json_response['posts'].map { |p| p['id'] }
+
+        expect(page1_ids.size).to eq(20)
+        expect(page2_ids.size).to eq(5)
+        expect(page1_ids & page2_ids).to be_empty
+        all_ids = followed_user.posts.pluck(:id).sort.reverse
+        expect(page1_ids + page2_ids).to eq(all_ids)
+      end
+    end
+
+    context '不正なcursor値の場合' do
+      it '非数値文字列で400を返す' do
+        get '/api/timeline', params: { cursor: 'abc' }
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response['errors']).to be_present
+      end
+
+      it '0で400を返す' do
+        get '/api/timeline', params: { cursor: '0' }
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it '負数で400を返す' do
+        get '/api/timeline', params: { cursor: '-1' }
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/requests/api/timelines_spec.rb
+++ b/spec/requests/api/timelines_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require 'swagger_helper'
+require 'support/post_schema_helper'
+
+RSpec.describe 'Api::Timelines', type: :request do
+  path '/api/timeline' do
+    get 'タイムラインを取得する' do
+      tags 'Timeline'
+      produces 'application/json'
+
+      let(:user) { create(:user) }
+
+      response '200', '取得成功' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: POST_LIST_PROPERTIES,
+                 required: POST_LIST_REQUIRED
+               }
+
+        context 'フォロー中ユーザーと自分の投稿が返る' do
+          let(:followed_user) { create(:user) }
+          let!(:followed_post) { create(:post, user: followed_user) }
+          let!(:own_post) { create(:post, user: user) }
+          let!(:unfollowed_post) { create(:post) }
+
+          before do
+            create(:relationship, follower: user, following: followed_user)
+            sign_in user
+          end
+
+          run_test! do
+            ids = json_response.map { |p| p['id'] }
+            expect(ids).to include(followed_post.id, own_post.id)
+            expect(ids).not_to include(unfollowed_post.id)
+          end
+        end
+
+        context 'フォローなし・自分の投稿もない場合は空配列' do
+          let!(:other_post) { create(:post) }
+
+          before { sign_in user }
+
+          run_test! do
+            expect(json_response).to eq([])
+          end
+        end
+      end
+
+      response '401', '未ログイン' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string }
+               },
+               required: %w[error]
+
+        run_test!
+      end
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -863,6 +863,72 @@ paths:
           description: 未ログイン
         '404':
           description: フォローしていない相手を削除しようとした場合
+  "/api/timeline":
+    get:
+      summary: タイムラインを取得する
+      tags:
+      - Timeline
+      responses:
+        '200':
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    caption:
+                      type: string
+                      nullable: true
+                    imageUrls:
+                      type: array
+                      items:
+                        type: string
+                    userName:
+                      type: string
+                    userAvatar:
+                      type: string
+                      nullable: true
+                    likedCount:
+                      type: integer
+                    likesSummary:
+                      type: string
+                      nullable: true
+                    timeAgo:
+                      type: string
+                    isLiked:
+                      type: boolean
+                    isOwn:
+                      type: boolean
+                    mostRecentLikerName:
+                      type: string
+                    commentsCount:
+                      type: integer
+                  required:
+                  - id
+                  - imageUrls
+                  - userName
+                  - userAvatar
+                  - likedCount
+                  - timeAgo
+                  - isLiked
+                  - isOwn
+                  - mostRecentLikerName
+                  - commentsCount
+        '401':
+          description: 未ログイン
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
   "/api/auth/token":
     get:
       summary: 認可コードからJWTを取得する

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -868,56 +868,74 @@ paths:
       summary: タイムラインを取得する
       tags:
       - Timeline
+      parameters:
+      - name: cursor
+        in: query
+        required: false
+        description: 前回取得した最後の投稿のID
+        schema:
+          type: string
       responses:
         '200':
-          description: 取得成功
+          description: タイムライン取得成功
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                    caption:
-                      type: string
-                      nullable: true
-                    imageUrls:
-                      type: array
-                      items:
-                        type: string
-                    userName:
-                      type: string
-                    userAvatar:
-                      type: string
-                      nullable: true
-                    likedCount:
-                      type: integer
-                    likesSummary:
-                      type: string
-                      nullable: true
-                    timeAgo:
-                      type: string
-                    isLiked:
-                      type: boolean
-                    isOwn:
-                      type: boolean
-                    mostRecentLikerName:
-                      type: string
-                    commentsCount:
-                      type: integer
-                  required:
-                  - id
-                  - imageUrls
-                  - userName
-                  - userAvatar
-                  - likedCount
-                  - timeAgo
-                  - isLiked
-                  - isOwn
-                  - mostRecentLikerName
-                  - commentsCount
+                type: object
+                properties:
+                  posts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        caption:
+                          type: string
+                          nullable: true
+                        imageUrls:
+                          type: array
+                          items:
+                            type: string
+                        userName:
+                          type: string
+                        userAvatar:
+                          type: string
+                          nullable: true
+                        likedCount:
+                          type: integer
+                        likesSummary:
+                          type: string
+                          nullable: true
+                        timeAgo:
+                          type: string
+                        isLiked:
+                          type: boolean
+                        isOwn:
+                          type: boolean
+                        mostRecentLikerName:
+                          type: string
+                        commentsCount:
+                          type: integer
+                      required:
+                      - id
+                      - imageUrls
+                      - userName
+                      - userAvatar
+                      - likedCount
+                      - timeAgo
+                      - isLiked
+                      - isOwn
+                      - mostRecentLikerName
+                      - commentsCount
+                  nextCursor:
+                    type: string
+                    nullable: true
+                  hasMore:
+                    type: boolean
+                required:
+                - posts
+                - hasMore
         '401':
           description: 未ログイン
           content:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -935,7 +935,21 @@ paths:
                     type: boolean
                 required:
                 - posts
+                - nextCursor
                 - hasMore
+        '400':
+          description: cursorが不正
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - errors
         '401':
           description: 未ログイン
           content:


### PR DESCRIPTION
## 概要

`GET /api/timeline` エンドポイントを追加し、フォロー中ユーザーと自分の投稿をカーソルベースページネーションで取得できるようにする。

## 変更内容

- **コントローラ** (`app/controllers/api/timelines_controller.rb`): `timeline#index` アクションを新規作成。`cursor` パラメータによるキーセットページネーション（`WHERE posts.id < cursor`）で、`limit(21)` で1件多く取得し `hasMore` を判定。不正な `cursor` 値には400を返す
- **モデル** (`app/models/post.rb`): `timeline_for` スコープを追加。フォロー中ユーザー + 自分の投稿をサブクエリで取得
- **ルーティング** (`config/routes.rb`): `resources :timeline, only: [:index]` を追加
- **テスト**:
  - リクエストspec（16ケース）: rswag契約（200/400/401）、フィルタリング、順序、複数フォロー、ページネーション境界（20/21/25件）、2ページ完全性、不正cursor
  - モデルspec（5ケース）: `timeline_for` スコープの単体テスト
- **Swagger**: 200/400/401レスポンスのスキーマを自動生成

## レビューポイント

- `order(id: :desc)` を採用（`created_at` ではなく）。投稿は作成後にupdateされないため `id` 順 = 新しい順で問題ない想定
- cursorバリデーションに `Integer(params[:cursor], exception: false)` を使用し、非数値・0・負数を明示的に拒否
- `.to_a` でクエリを実体化してから `.size` を呼ぶことで、`COUNT(*)` による余分なクエリを防止
- レスポンスのcamelCaseキー（`nextCursor`, `hasMore`）はプレーンハッシュで直接記述（AMSのkey_transformを経由しない）。ページネーション付きエンドポイントの構造的制約

## テスト方法

```bash
RAILS_ENV=test bundle exec rspec spec/requests/api/timelines_spec.rb spec/models/post_spec.rb
```

## API仕様

```
GET /api/timeline            # 最新20件
GET /api/timeline?cursor=123 # id=123より前の20件
GET /api/timeline?cursor=abc # 400 Bad Request
```

レスポンス:
```json
{
  "posts": [...],
  "nextCursor": "100",
  "hasMore": true
}
```