### PR TITLE
fix: seed投稿のID順とcreated_at順のズレを修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,18 +83,25 @@ begin
     }
   end
 
+  # created_at を先に割り振り、昇順でinsertすることでID順 = 時系列順を保証
   all_posts_data.sort_by! { |p| p[:user].id }
 
+  now = Time.current
+  hours_elapsed_today = [((now - now.beginning_of_day) / 1.hour).to_i, 1].max
   user_post_counts = Hash.new(0)
+
   all_posts_data.each do |post_data|
     user = post_data[:user]
-    now = Time.current
-    hours_elapsed_today = [((now - now.beginning_of_day) / 1.hour).to_i, 1].max
-
     created_at = user_post_counts[user.id] == 0 ? now - rand(1..hours_elapsed_today).hours : now - rand(1..720).hours
     user_post_counts[user.id] += 1
+    post_data[:created_at] = created_at
+  end
 
-    post = user.posts.build(caption: post_data[:caption], created_at: created_at, updated_at: created_at)
+  all_posts_data.sort_by! { |p| p[:created_at] }
+
+  all_posts_data.each do |post_data|
+    user = post_data[:user]
+    post = user.posts.build(caption: post_data[:caption], created_at: post_data[:created_at], updated_at: post_data[:created_at])
 
     attached_count = 0
     (1..3).each do |img_suffix|


### PR DESCRIPTION
## 概要

seedで生成される投稿のID順と`created_at`順が一致せず、`order(id: :desc)`で取得するタイムラインの表示順が時系列と異なっていた問題を修正。

## 原因

`all_posts_data.sort_by! { |p| p[:user].id }` でユーザーID順にまとめてinsertしていたため、ユーザーごとにID範囲がブロック化されていた。一方`created_at`はランダムに割り振られるため、ID順と時系列が乖離。

## 変更内容

- `created_at` を全投稿に先に割り振る（2パス方式）
- `created_at` 昇順でソートしてからinsertすることで、ID順 = 時系列順を保証
- 投稿内容と画像の割り当てロジックは変更なし

## テスト方法

```bash
docker-compose exec rails bash -c "rails db:seed"
```

seed実行後、タイムラインで投稿が時系列順に表示されることを確認。