### PR TITLE
chore: Herokuデプロイ環境の修正（Redis SSL + 画像配信高速化）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
     url_options = ActiveStorage::Current.url_options || {}
     return Rails.application.routes.url_helpers.rails_blob_path(avatar, only_path: true) unless url_options[:host]
 
-    Rails.application.routes.url_helpers.rails_blob_url(avatar, url_options)
+    avatar.url
   end
 
   def follow!(target_user)

--- a/app/serializers/concerns/post_attributes.rb
+++ b/app/serializers/concerns/post_attributes.rb
@@ -13,7 +13,7 @@ module PostAttributes
     url_options = ActiveStorage::Current.url_options || {}
     return object.images.map { |image| rails_blob_path(image, only_path: true) } unless url_options[:host]
 
-    object.images.map { |image| rails_blob_url(image, url_options) }
+    object.images.map(&:url)
   end
 
   def user_name

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -59,7 +59,7 @@ class NotificationSerializer < ActiveModel::Serializer
     url_options = ActiveStorage::Current.url_options || {}
     return rails_blob_path(image, only_path: true) unless url_options[:host]
 
-    rails_blob_url(image, url_options)
+    image.url
   end
 
   def time_ago

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,4 +5,6 @@ url =
     ENV.fetch('REDIS_URL', 'redis://localhost:6379/1')
   end
 
-Rails.application.config.x.redis = Redis.new(url:)
+ssl_params = url.start_with?('rediss://') ? { verify_mode: OpenSSL::SSL::VERIFY_NONE } : {}
+
+Rails.application.config.x.redis = Redis.new(url:, ssl_params:)


### PR DESCRIPTION
## 概要

Herokuデプロイで発生した2つの問題を修正する。

1. **Redis SSL証明書エラー**: Heroku Redisの自己署名証明書によりOAuth認証フローが失敗
2. **画像表示の遅延**: `rails_blob_url`によるRails経由リダイレクトで画像取得が2段階リクエストになっていた

## 変更内容

### Redis SSL対応
- `config/initializers/redis.rb`: `rediss://`（SSL）の場合のみ `VERIFY_NONE` でSSL検証をスキップ
- ローカル開発（`redis://`）には影響なし

### 画像URL S3直接配信
- `app/models/user.rb`: アバターURLを `rails_blob_url` → `avatar.url` に変更
- `app/serializers/concerns/post_attributes.rb`: 投稿画像URLを `rails_blob_url` → `image.url` に変更
- `app/serializers/notification_serializer.rb`: 通知サムネイルURLを `rails_blob_url` → `image.url` に変更

**Before**: ブラウザ → Heroku (302) → S3 = 2リクエスト
**After**: ブラウザ → S3（署名付きURL）= 1リクエスト

## レビューポイント

- `VERIFY_NONE` はHeroku Redis公式の推奨設定（自己署名証明書のため）
- `blob.url` の署名付きURLはデフォルト5分間有効。通常フローでは問題なし
- 開発環境は `rails_blob_path(only_path: true)` のまま変更なし

## テスト方法

- Herokuにデプロイ後、Google OAuth認証フローが正常に完了することを確認
- APIレスポンスの画像URLが `https://s3.ap-southeast-2.amazonaws.com/...` 形式になっていることを確認
- 画像表示速度が改善されていることを確認